### PR TITLE
WMS-30425: remove podfile validation which is not required after cordova 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The main goal of wm-cordova-cli is to simplify generation of APK or IPA for Wave
 
 -   Linux or MAC or Windows   
 -   Latest Android Studio    
--   Node 18.x ([https://nodejs.org/en/blog/release/v10.18.0/](https://nodejs.org/en/download/))    
+-   Node 20.17.x ([https://nodejs.org/en/blog/release/v20.17.0/](https://nodejs.org/en/download/))    
 -   GIT ([https://git-scm.com/download](https://git-scm.com/download))    
 -   Java 17 (for Wavemaker 11.2 and WaveMaker 10.16 projects) or Java 8 for earlier versions     
--   Gradle 8.7 ([https://gradle.org/releases/](https://gradle.org/releases/))    
+-   Gradle 8.13 ([https://gradle.org/releases/](https://gradle.org/releases/))    
 -   KeyStore file for production release builds ([https://developer.android.com/studio/publish/app-signing#generate-key](https://developer.android.com/studio/publish/app-signing#generate-key))    
 -   Install wm-cordova-cli (npm install -g @wavemaker/wm-cordova-cli)    
 -   Make sure JAVA_HOME, ANDROID_SDK and GRADLE_HOME are set in the environment variables and also in PATH.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavemaker/wm-cordova-cli",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "command line tool to easily build a wavemaker mobile project",
   "main": "index.js",
   "preferGlobal": true,

--- a/src/ios.js
+++ b/src/ios.js
@@ -97,6 +97,10 @@ async function getPackageType(provisionalFile) {
 async function turnOffPodCodeSigning(projectDir) {
     const iosProjectPath = `${projectDir}/platforms/ios`;
     const podFilePath = `${iosProjectPath}/Podfile`;
+    if (!fs.existsSync(podFilePath)) {
+        console.warn('[wm-cordova-cli] Podfile not found, skipping code signing disable step');
+        return;
+    }
     let podFileContent = fs.readFileSync(podFilePath);
     if (podFileContent.indexOf(`config.build_settings['CODE_SIGNING_ALLOWED']`) < 0) {
         podFileContent += `


### PR DESCRIPTION
1. Podfile issue after cordova-ios: 8.0.0 upgrade has been fixed.
2. Bump package version.